### PR TITLE
Firefox SignaturePad.fromDataURL fix

### DIFF
--- a/signature_pad.js
+++ b/signature_pad.js
@@ -55,10 +55,13 @@ var SignaturePad = (function (document) {
     };
 
     SignaturePad.prototype.fromDataURL = function (dataUrl) {
+        var self = this;
         this._reset();
         var image = new Image();
         image.src = dataUrl;
-        this._ctx.drawImage(image, 0, 0, this._canvas.width, this._canvas.height);
+        image.onload = function() {
+            self._ctx.drawImage(image, 0, 0, self._canvas.width, self._canvas.height);
+        };
         this._isEmpty = false;
     };
 


### PR DESCRIPTION
Added image.onload.
Without it, firefox failing to load image into canvas. Only after second visit it will properly display.

Example is here 
http://jsfiddle.net/sETn7/

Expected behavior:
browser will display signature

Actual result (FF 24; Windows 8.1 x64):
browser will display signature only on second visit (for example, if you will clean your cache and reload page - browser will not display signature)
