### PR TITLE
Fixes bug where stroke becomes very thin and strokes are sometimes ignored completely depending on event timing.

### DIFF
--- a/signature_pad.js
+++ b/signature_pad.js
@@ -282,7 +282,7 @@ var SignaturePad = (function (document) {
     };
 
     Point.prototype.velocityFrom = function (start) {
-        return this.distanceTo(start) / (this.time - start.time);
+        return (this.time !== start.time) ? this.distanceTo(start) / (this.time - start.time) : 1;
     };
 
     Point.prototype.distanceTo = function (start) {


### PR DESCRIPTION
Fixes bug where stroke becomes very thin and strokes are sometimes ignored completely depending on event timing. This occurred on at least Chrome.

![image](https://f.cloud.github.com/assets/1131906/1581915/37d3f3f6-51e2-11e3-9986-891152f3aa8c.png)

Note to self: Next time remember to create a new branch, even for a one-liner.
