### PR TITLE
adding version number to bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "signature_pad",
   "main": "signature_pad.js",
+  "version": "1.3.2",
   "homepage": "https://github.com/szimek/signature_pad",
   "authors": [
     "Szymon Nowak <szimek@gmail.com>"


### PR DESCRIPTION
During some of my Capistrano deploys via codeship I am getting errors due to the bower.json file not containing a version number. Would be great if this could be added. Thanks!
