### PR TITLE
Fix touchend event on mobile devices and Phonegap applications

### DIFF
--- a/signature_pad.js
+++ b/signature_pad.js
@@ -150,12 +150,19 @@ var SignaturePad = (function (document) {
             self._strokeUpdate(touch);
         });
 
-        document.addEventListener("touchend", function (event) {
+		this._canvas.addEventListener("touchend", function (event) {
             var wasCanvasTouched = event.target === self._canvas;
             if (wasCanvasTouched) {
                 self._strokeEnd(event);
             }
         });
+
+        /* document.addEventListener("touchend", function (event) {
+            var wasCanvasTouched = event.target === self._canvas;
+            if (wasCanvasTouched) {
+                self._strokeEnd(event);
+            }
+        }); */
     };
 
     SignaturePad.prototype.isEmpty = function () {


### PR DESCRIPTION
The following changeset triggers the onEnd callback function correctly.  Previous version didn't fire the event in native mobile apps.