### PR TITLE
Fix bug when scaling canvas with CSS

### DIFF
--- a/signature_pad.js
+++ b/signature_pad.js
@@ -186,11 +186,19 @@ var SignaturePad = (function (document) {
         this._ctx.fillStyle = this.penColor;
     };
 
+    SignaturePad.prototype._getCanvasWidthScale = function () {
+        return this._canvas.clientWidth / this._canvas.width;
+    };
+    
+    SignaturePad.prototype._getCanvasHeightScale = function(){
+        return this._canvas.clientHeight / this._canvas.height;
+    }
+
     SignaturePad.prototype._createPoint = function (event) {
         var rect = this._canvas.getBoundingClientRect();
         return new Point(
-            event.clientX - rect.left,
-            event.clientY - rect.top
+            (event.clientX - rect.left) / this._getCanvasWidthScale(),
+            (event.clientY - rect.top) / this._getCanvasHeightScale()
         );
     };
 


### PR DESCRIPTION
Previously, setting the canvas width and height via CSS "width" and "height" properties
would create a scale multiplier that SignaturePad did not account for. This caused the
line to show up offset from where the user attempted to draw.

To reproduce, open in browser and set

```
canvas {
    width: 200px;
    height: 100px;
}
```

with those widths and heights differing from the actual canvas width and height. Then
attempt to draw.

With this commit, the scale multiplier is taken into account, and scaling the canvas with
CSS works just fine, with drawn lines appearing directly under the cursor.

_STILL NEEDS MINIFICATION_
