### PR TITLE
don't create canvas from empty string

### DIFF
--- a/signature_pad.js
+++ b/signature_pad.js
@@ -115,6 +115,9 @@ var SignaturePad = (function (document) {
     };
 
     SignaturePad.prototype.fromDataURL = function (dataUrl) {
+        if (!dataUrl) {
+            return;
+        }
         var self = this,
             image = new Image(),
             ratio = window.devicePixelRatio || 1,


### PR DESCRIPTION
I understand that this might be a specific issue happening in my project. We're using a generic system where we bind data to various controls, among them your awesome signature pad. When we load something from our database using `fromDataURL` we get a canvas object, even when the string we've passed into the load function was empty. Later on the check for mandatory fields wrongly reports that the field contains a signature.

You can test this by running this:
```javascript
signaturePad.clear();
signaturePad.fromDataURL("");
signaturePad.isEmpty(); // will be false
```

Most people will most likely not have a problem to avoid calling `fromDataURL` when their string is empty, but I still believe that this change would make signature pad a bit more solid.