### PR TITLE
Prevent duplicate events on tap in iOS Safari

### DIFF
--- a/src/signature_pad.js
+++ b/src/signature_pad.js
@@ -58,6 +58,7 @@ var SignaturePad = (function (document) {
         this._handleTouchEnd = function (event) {
             var wasCanvasTouched = event.target === self._canvas;
             if (wasCanvasTouched) {
+                event.preventDefault();
                 self._strokeEnd(event);
             }
         };


### PR DESCRIPTION
This change prevents iOS Safari from firing an mouse down & mouse up event in addition to the touch start and touch end event if you just tap the screen.

This resolves #120.