### PR TITLE
Restrict form submission

### DIFF
--- a/example/js/app.js
+++ b/example/js/app.js
@@ -24,6 +24,8 @@ signaturePad = new SignaturePad(canvas);
 
 clearButton.addEventListener("click", function (event) {
     signaturePad.clear();
+	event.preventDefault();
+	return false;
 });
 
 saveButton.addEventListener("click", function (event) {
@@ -32,4 +34,6 @@ saveButton.addEventListener("click", function (event) {
     } else {
         window.open(signaturePad.toDataURL());
     }
+	event.preventDefault();
+	return false;
 });


### PR DESCRIPTION
If the signature stays in a form then clicking on the button was submitting the form. So now its prevented.