### PR TITLE
Fixed "fromDataURL" function making weird resize

### DIFF
--- a/src/signature_pad.js
+++ b/src/signature_pad.js
@@ -88,8 +88,8 @@ var SignaturePad = (function (document) {
         var self = this,
             image = new Image(),
             ratio = window.devicePixelRatio || 1,
-            width = this._canvas.width / ratio,
-            height = this._canvas.height / ratio;
+            width = this._canvas.width,
+            height = this._canvas.height;
 
         this._reset();
         image.src = dataUrl;


### PR DESCRIPTION
In an attempt to resize the canvas in my component, I stumbled across a weird behavior: whenever I called fromDataURL and gave it the old Base64 contents, it would shrink the image.

I inspected the code to look for anything I might've been doing wrong and was suspicious about using ratios in resizes, since I recently read that JavaScript now handles that without pixel densities being involved. Upon removing that, fromDataURL started working as expected on all my devices (iPad mini, iPad2, Samsung Galaxy Tab 2 and a OnePlus X; desktop also works, with device emulation).

Please review and test on older devices (the iPad mini is running iOS 8.4.1 and OPX is running Android 5; everything else is running its latest version).
