### PR TITLE
Fix issue with smaller image on mobile device

### DIFF
--- a/src/signature_pad.js
+++ b/src/signature_pad.js
@@ -87,7 +87,7 @@ var SignaturePad = (function (document) {
     SignaturePad.prototype.fromDataURL = function (dataUrl) {
         var self = this,
             image = new Image(),
-            ratio = window.devicePixelRatio || 1,
+            ratio = /*window.devicePixelRatio ||*/ 1,
             width = this._canvas.width / ratio,
             height = this._canvas.height / ratio;
 


### PR DESCRIPTION
If use c.fromDataURL(c.toDataURL()) from one canvas to another on the same page, it draws smaller image.
It can be reproduced on both, desktop browser with a scale changed, and mobile browser.

The idea of this fix is to eliminate ratio from calculations. It seems that modern browsers do it themselves.
