### PR TITLE
Fix focus

### DIFF
--- a/example/css/signature-pad.css
+++ b/example/css/signature-pad.css
@@ -86,6 +86,13 @@ body {
   }
 
 .m-signature-pad--footer
+  .description
+    input {
+      margin-left: 10px;
+      width: 60px;
+}
+
+.m-signature-pad--footer
   .button {
     position: absolute;
     bottom: 0;

--- a/example/index.html
+++ b/example/index.html
@@ -34,7 +34,10 @@
       <canvas></canvas>
     </div>
     <div class="m-signature-pad--footer">
-      <div class="description">Sign above</div>
+      <div class="description">
+        Sign above
+        <input type="text" name="fullName" value="Your name">
+      </div>
       <button type="button" class="button clear" data-action="clear">Clear</button>
       <button type="button" class="button save" data-action="save">Save</button>
     </div>

--- a/example/js/signature_pad.js
+++ b/example/js/signature_pad.js
@@ -76,6 +76,9 @@ var SignaturePad = (function (document) {
         };
 
         this._handleTouchStart = function (event) {
+            // Steal focus so keyboard won't popup on mobile
+            document.activeElement.blur();
+
             if (event.targetTouches.length == 1) {
                 var touch = event.changedTouches[0];
                 self._strokeBegin(touch);

--- a/signature_pad.js
+++ b/signature_pad.js
@@ -76,6 +76,9 @@ var SignaturePad = (function (document) {
         };
 
         this._handleTouchStart = function (event) {
+            // Steal focus so keyboard won't popup on mobile
+            document.activeElement.blur();
+
             if (event.targetTouches.length == 1) {
                 var touch = event.changedTouches[0];
                 self._strokeBegin(touch);


### PR DESCRIPTION
I noticed this problem on mobile devices where if you have input selected and you have pressed back button to hide, the keyboard reappears after you start signing.

At the beginning where the input has the focus but user has hidden the keyboard with back button:
![screenshot_20160627-120704 1](https://cloud.githubusercontent.com/assets/53298/16374673/382308ea-3c60-11e6-92c1-afbb6520e708.png)

After trying to sign something, the keyboard pops up:
![screenshot_20160627-120714](https://cloud.githubusercontent.com/assets/53298/16374675/3a3b9f7a-3c60-11e6-80bd-ccdb29299ae2.png)

This isn't a perfect solution. Stealing focus is not ideal **1)** if you have external keyboard and there might be a case where **2)** user wants to have the keyboard up AND sign at the same time. However, that is not very common and the focus stealing already happens on desktop.
