### PR TITLE
Allow custom ratio/width/height in fromDataURL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## Changelog
+
+### master
+
+*   Allow custom ratio/width/height when loading data URL onto canvas
+
 ### 2.1.1
 *   Fixed a bug where default value was applied for throttle when throttle was set to 0. ([mkrause](https://github.com/mkrause) in [#247](https://github.com/szimek/signature_pad/pull/247))
 

--- a/src/signature_pad.js
+++ b/src/signature_pad.js
@@ -92,12 +92,11 @@ SignaturePad.prototype.clear = function () {
   this._isEmpty = true;
 };
 
-SignaturePad.prototype.fromDataURL = function (dataUrl, options) {
+SignaturePad.prototype.fromDataURL = function (dataUrl, options = {}) {
   const image = new Image();
-  const opts = options || {};
-  const ratio = opts.ratio || window.devicePixelRatio || 1;
-  const width = opts.width || (this._canvas.width / ratio);
-  const height = opts.height || (this._canvas.height / ratio);
+  const ratio = options.ratio || window.devicePixelRatio || 1;
+  const width = options.width || (this._canvas.width / ratio);
+  const height = options.height || (this._canvas.height / ratio);
 
   this._reset();
   image.src = dataUrl;

--- a/src/signature_pad.js
+++ b/src/signature_pad.js
@@ -92,11 +92,12 @@ SignaturePad.prototype.clear = function () {
   this._isEmpty = true;
 };
 
-SignaturePad.prototype.fromDataURL = function (dataUrl) {
+SignaturePad.prototype.fromDataURL = function (dataUrl, options) {
   const image = new Image();
-  const ratio = window.devicePixelRatio || 1;
-  const width = this._canvas.width / ratio;
-  const height = this._canvas.height / ratio;
+  const opts = options || {};
+  const ratio = opts.ratio || window.devicePixelRatio || 1;
+  const width = opts.width || (this._canvas.width / ratio);
+  const height = opts.height || (this._canvas.height / ratio);
 
   this._reset();
   image.src = dataUrl;


### PR DESCRIPTION
Dear @szimek,

I know you're as busy as I am :) I'd still kindly ask you consider this PR as a small change that potentially solves a number of issues and PRs in one strike.

It simply allows a custom ratio, width, and height to be passed in when loading an image onto the canvas.

It should solve these Issues:

* The last comment in #89 suggests a monkey patch that is solved by this PR
* #105 appears to be solvable by overriding width/height via `fromDataURL` as implemented in this PR
* #153 complains about guessing the ratio automagically, should be solved by this PR
* #200 describes just the problem that this PR solves

And you should be able to close these PRs:

* #241 suggests to shrink any larger image to the canvas. While this makes sense at first sight, it's probably magic that may not fit all. This PR allows the developer to do the calculation outside of the SignaturePad library and simply pass in the resulting width and height.
* #165 butchers away any ratio guessing. That only solves one specific problem. This PR solves it by passing in `ratio: 1` as an argument.
* #164 removes the ratio altogeher. That also works for that person's use case but is not desireable for others. This PR solves it by passing in `ratio: 1` as an argument.

If there is anything more I could do to assist, let me know.