### PR TITLE
Fix bug when style.zoom is used

### DIFF
--- a/src/signature_pad.js
+++ b/src/signature_pad.js
@@ -146,8 +146,8 @@ SignaturePad.prototype._strokeBegin = function (event) {
 };
 
 SignaturePad.prototype._strokeUpdate = function (event) {
-  const x = event.clientX;
-  const y = event.clientY;
+  const x = event.clientX / (document.body.style.zoom || 1);
+  const y = event.clientY / (document.body.style.zoom || 1);
 
   const point = this._createPoint(x, y);
   const { curve, widths } = this._addPoint(point);


### PR DESCRIPTION
Previously, setting a zoom in the document (document.body.style.zoom = x)
would create a scale multiplier that SignaturePad did not account for. This caused the
line to show up offset from where the user attempted to draw.

With this commit the zoom is taken into account when creating a point.

The bug can be seen here https://jsfiddle.net/0veL8mmb/