### PR TITLE
Fix `minDistance` not being correctly initialized when set to zero.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### master
+#### Bug Fixes
+*   Fix `minDistance` not being correctly initialized when set to zero. ([remomueller](https://github.com/remomueller) closes [#299](https://github.com/szimek/signature_pad/issues/299).
+
 ### 2.3.0
 #### Bug Fixes
 *   Updated demo to call `SignaturePad#clear` on window resize, to make sure that `SignaturePad#isEmpty` returns the correct value. Closes [#94](https://github.com/szimek/signature_pad/issues/94).

--- a/src/signature_pad.js
+++ b/src/signature_pad.js
@@ -10,7 +10,7 @@ function SignaturePad(canvas, options) {
   this.minWidth = opts.minWidth || 0.5;
   this.maxWidth = opts.maxWidth || 2.5;
   this.throttle = 'throttle' in opts ? opts.throttle : 16; // in miliseconds
-  this.minDistance = opts.minDistance || 5;
+  this.minDistance = 'minDistance' in opts ? opts.minDistance : 5;
 
   if (this.throttle) {
     this._strokeMoveUpdate = throttle(SignaturePad.prototype._strokeUpdate, this.throttle);


### PR DESCRIPTION
Closes #299. 