### PR TITLE
Add support for pointer events

### DIFF
--- a/example/css/signature-pad.css
+++ b/example/css/signature-pad.css
@@ -79,8 +79,7 @@ body {
   border: 1px solid #f4f4f4;
 }
 
-.signature-pad--body
-canvas {
+.signature-pad--body canvas {
   position: absolute;
   left: 0;
   top: 0;

--- a/example/js/signature_pad.js
+++ b/example/js/signature_pad.js
@@ -189,6 +189,7 @@ function SignaturePad(canvas, options) {
 
   if (this.supportsPointerEvents) {
     this._handlePointerDown = function (event) {
+      event.preventDefault();
       if (event.which === 1) {
         self._pointerDown = true;
         self._strokeBegin(event);
@@ -196,12 +197,14 @@ function SignaturePad(canvas, options) {
     };
 
     this._handlePointerMove = function (event) {
+      event.preventDefault();
       if (self._pointerDown) {
         self._strokeMoveUpdate(event);
       }
     };
 
     this._handlePointerUp = function (event) {
+      event.preventDefault();
       if (event.which === 1 && self._pointerDown) {
         self._pointerDown = false;
         self._strokeEnd(event);

--- a/example/js/signature_pad.js
+++ b/example/js/signature_pad.js
@@ -114,7 +114,7 @@ function SignaturePad(canvas, options) {
   var self = this;
   var opts = options || {};
 
-  this.supportsPointerEvents = window.PointerEvent !== 'undefined';
+  this.supportsPointerEvents = !!window.PointerEvent;
   this.velocityFilterWeight = opts.velocityFilterWeight || 0.7;
   this.minWidth = opts.minWidth || 0.5;
   this.maxWidth = opts.maxWidth || 2.5;
@@ -142,7 +142,7 @@ function SignaturePad(canvas, options) {
   // We need add these inline so they are available to unbind while still having
   // access to 'self' we could use _.bind but it's not worth adding a dependency.
   this._handleMouseDown = function (event) {
-    if (event.which === 1) {
+    if (event.button === 0) {
       self._mouseButtonDown = true;
       self._strokeBegin(event);
     }
@@ -155,7 +155,7 @@ function SignaturePad(canvas, options) {
   };
 
   this._handleMouseUp = function (event) {
-    if (event.which === 1 && self._mouseButtonDown) {
+    if (event.button === 0 && self._mouseButtonDown) {
       self._mouseButtonDown = false;
       self._strokeEnd(event);
     }
@@ -189,30 +189,33 @@ function SignaturePad(canvas, options) {
 
   if (this.supportsPointerEvents) {
     this._handlePointerDown = function (event) {
-      event.preventDefault();
-      if (event.which === 1) {
+      // event.preventDefault();
+
+      if (event.button === 0) {
         self._pointerDown = true;
         self._strokeBegin(event);
       }
     };
 
     this._handlePointerMove = function (event) {
-      event.preventDefault();
+      // event.preventDefault();
+
       if (self._pointerDown) {
         self._strokeMoveUpdate(event);
       }
     };
 
     this._handlePointerUp = function (event) {
-      event.preventDefault();
-      if (event.which === 1 && self._pointerDown) {
+      // event.preventDefault();
+
+      if (event.button === 0 && self._pointerDown) {
         self._pointerDown = false;
         self._strokeEnd(event);
       }
     };
   }
 
-  // Enable mouse and touch event handlers
+  // Enable pointer or mouse/touch event handlers
   this.on();
 }
 
@@ -264,11 +267,16 @@ SignaturePad.prototype.toDataURL = function (type) {
 };
 
 SignaturePad.prototype.on = function () {
+  // Pass touch events to canvas element on mobile IE11 and Edge.
+  this._canvas.style.msTouchAction = 'none';
+  this._canvas.style.touchAction = 'none';
+
   if (this.supportsPointerEvents) {
     this._handlePointerEvents();
+  } else {
+    this._handleMouseEvents();
+    this._handleTouchEvents();
   }
-  this._handleMouseEvents();
-  this._handleTouchEvents();
 };
 
 SignaturePad.prototype.off = function () {
@@ -280,15 +288,15 @@ SignaturePad.prototype.off = function () {
     this._canvas.removeEventListener('pointerdown', this._handlePointerDown);
     this._canvas.removeEventListener('pointermove', this._handlePointerMove);
     document.removeEventListener('pointerup', this._handlePointerUp);
+  } else {
+    this._canvas.removeEventListener('mousedown', this._handleMouseDown);
+    this._canvas.removeEventListener('mousemove', this._handleMouseMove);
+    document.removeEventListener('mouseup', this._handleMouseUp);
+
+    this._canvas.removeEventListener('touchstart', this._handleTouchStart);
+    this._canvas.removeEventListener('touchmove', this._handleTouchMove);
+    this._canvas.removeEventListener('touchend', this._handleTouchEnd);
   }
-
-  this._canvas.removeEventListener('mousedown', this._handleMouseDown);
-  this._canvas.removeEventListener('mousemove', this._handleMouseMove);
-  document.removeEventListener('mouseup', this._handleMouseUp);
-
-  this._canvas.removeEventListener('touchstart', this._handleTouchStart);
-  this._canvas.removeEventListener('touchmove', this._handleTouchMove);
-  this._canvas.removeEventListener('touchend', this._handleTouchEnd);
 };
 
 SignaturePad.prototype.isEmpty = function () {
@@ -372,10 +380,6 @@ SignaturePad.prototype._handleMouseEvents = function () {
 };
 
 SignaturePad.prototype._handleTouchEvents = function () {
-  // Pass touch events to canvas element on mobile IE11 and Edge.
-  this._canvas.style.msTouchAction = 'none';
-  this._canvas.style.touchAction = 'none';
-
   this._canvas.addEventListener('touchstart', this._handleTouchStart);
   this._canvas.addEventListener('touchmove', this._handleTouchMove);
   this._canvas.addEventListener('touchend', this._handleTouchEnd);

--- a/example/js/signature_pad.js
+++ b/example/js/signature_pad.js
@@ -114,6 +114,7 @@ function SignaturePad(canvas, options) {
   var self = this;
   var opts = options || {};
 
+  this.supportsPointerEvents = window.PointerEvent !== 'undefined';
   this.velocityFilterWeight = opts.velocityFilterWeight || 0.7;
   this.minWidth = opts.minWidth || 0.5;
   this.maxWidth = opts.maxWidth || 2.5;
@@ -186,6 +187,28 @@ function SignaturePad(canvas, options) {
     }
   };
 
+  if (this.supportsPointerEvents) {
+    this._handlePointerDown = function (event) {
+      if (event.which === 1) {
+        self._pointerDown = true;
+        self._strokeBegin(event);
+      }
+    };
+
+    this._handlePointerMove = function (event) {
+      if (self._pointerDown) {
+        self._strokeMoveUpdate(event);
+      }
+    };
+
+    this._handlePointerUp = function (event) {
+      if (event.which === 1 && self._pointerDown) {
+        self._pointerDown = false;
+        self._strokeEnd(event);
+      }
+    };
+  }
+
   // Enable mouse and touch event handlers
   this.on();
 }
@@ -238,6 +261,9 @@ SignaturePad.prototype.toDataURL = function (type) {
 };
 
 SignaturePad.prototype.on = function () {
+  if (this.supportsPointerEvents) {
+    this._handlePointerEvents();
+  }
   this._handleMouseEvents();
   this._handleTouchEvents();
 };
@@ -246,7 +272,13 @@ SignaturePad.prototype.off = function () {
   // Pass touch events to canvas element on mobile IE11 and Edge.
   this._canvas.style.msTouchAction = 'auto';
   this._canvas.style.touchAction = 'auto';
-  
+
+  if (this.supportsPointerEvents) {
+    this._canvas.removeEventListener('pointerdown', this._handlePointerDown);
+    this._canvas.removeEventListener('pointermove', this._handlePointerMove);
+    document.removeEventListener('pointerup', this._handlePointerUp);
+  }
+
   this._canvas.removeEventListener('mousedown', this._handleMouseDown);
   this._canvas.removeEventListener('mousemove', this._handleMouseMove);
   document.removeEventListener('mouseup', this._handleMouseUp);
@@ -344,6 +376,12 @@ SignaturePad.prototype._handleTouchEvents = function () {
   this._canvas.addEventListener('touchstart', this._handleTouchStart);
   this._canvas.addEventListener('touchmove', this._handleTouchMove);
   this._canvas.addEventListener('touchend', this._handleTouchEnd);
+};
+
+SignaturePad.prototype._handlePointerEvents = function () {
+  this._canvas.addEventListener('pointerdown', this._handlePointerDown);
+  this._canvas.addEventListener('pointermove', this._handlePointerMove);
+  document.addEventListener('pointerup', this._handlePointerUp);
 };
 
 SignaturePad.prototype._reset = function () {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "module": "dist/signature_pad.mjs",
   "scripts": {
     "build": "gulp",
+    "start": "pushstate-server example",
     "watch": "gulp watch",
     "prepublishOnly": "npm run build"
   },

--- a/src/signature_pad.js
+++ b/src/signature_pad.js
@@ -6,7 +6,7 @@ function SignaturePad(canvas, options) {
   const self = this;
   const opts = options || {};
 
-  this.supportsPointerEvents = window.PointerEvent !== 'undefined';
+  this.supportsPointerEvents = !!window.PointerEvent;
   this.velocityFilterWeight = opts.velocityFilterWeight || 0.7;
   this.minWidth = opts.minWidth || 0.5;
   this.maxWidth = opts.maxWidth || 2.5;
@@ -34,7 +34,7 @@ function SignaturePad(canvas, options) {
   // We need add these inline so they are available to unbind while still having
   // access to 'self' we could use _.bind but it's not worth adding a dependency.
   this._handleMouseDown = function (event) {
-    if (event.which === 1) {
+    if (event.button === 0) {
       self._mouseButtonDown = true;
       self._strokeBegin(event);
     }
@@ -47,7 +47,7 @@ function SignaturePad(canvas, options) {
   };
 
   this._handleMouseUp = function (event) {
-    if (event.which === 1 && self._mouseButtonDown) {
+    if (event.button === 0 && self._mouseButtonDown) {
       self._mouseButtonDown = false;
       self._strokeEnd(event);
     }
@@ -64,7 +64,7 @@ function SignaturePad(canvas, options) {
   };
 
   this._handleTouchMove = function (event) {
-  // Prevent scrolling.
+    // Prevent scrolling.
     event.preventDefault();
 
     const touch = event.targetTouches[0];
@@ -81,30 +81,33 @@ function SignaturePad(canvas, options) {
 
   if (this.supportsPointerEvents) {
     this._handlePointerDown = function (event) {
-      event.preventDefault();
-      if (event.which === 1) {
+      // event.preventDefault();
+
+      if (event.button === 0) {
         self._pointerDown = true;
         self._strokeBegin(event);
       }
     };
 
     this._handlePointerMove = function (event) {
-      event.preventDefault();
+      // event.preventDefault();
+
       if (self._pointerDown) {
         self._strokeMoveUpdate(event);
       }
     };
 
     this._handlePointerUp = function (event) {
-      event.preventDefault();
-      if (event.which === 1 && self._pointerDown) {
+      // event.preventDefault();
+
+      if (event.button === 0 && self._pointerDown) {
         self._pointerDown = false;
         self._strokeEnd(event);
       }
     };
   }
 
-  // Enable mouse and touch event handlers
+  // Enable pointer or mouse/touch event handlers
   this.on();
 }
 
@@ -146,11 +149,16 @@ SignaturePad.prototype.toDataURL = function (type, ...options) {
 };
 
 SignaturePad.prototype.on = function () {
+  // Pass touch events to canvas element on mobile IE11 and Edge.
+  this._canvas.style.msTouchAction = 'none';
+  this._canvas.style.touchAction = 'none';
+
   if (this.supportsPointerEvents) {
     this._handlePointerEvents();
+  } else {
+    this._handleMouseEvents();
+    this._handleTouchEvents();
   }
-  this._handleMouseEvents();
-  this._handleTouchEvents();
 };
 
 SignaturePad.prototype.off = function () {
@@ -162,15 +170,15 @@ SignaturePad.prototype.off = function () {
     this._canvas.removeEventListener('pointerdown', this._handlePointerDown);
     this._canvas.removeEventListener('pointermove', this._handlePointerMove);
     document.removeEventListener('pointerup', this._handlePointerUp);
+  } else {
+    this._canvas.removeEventListener('mousedown', this._handleMouseDown);
+    this._canvas.removeEventListener('mousemove', this._handleMouseMove);
+    document.removeEventListener('mouseup', this._handleMouseUp);
+
+    this._canvas.removeEventListener('touchstart', this._handleTouchStart);
+    this._canvas.removeEventListener('touchmove', this._handleTouchMove);
+    this._canvas.removeEventListener('touchend', this._handleTouchEnd);
   }
-
-  this._canvas.removeEventListener('mousedown', this._handleMouseDown);
-  this._canvas.removeEventListener('mousemove', this._handleMouseMove);
-  document.removeEventListener('mouseup', this._handleMouseUp);
-
-  this._canvas.removeEventListener('touchstart', this._handleTouchStart);
-  this._canvas.removeEventListener('touchmove', this._handleTouchMove);
-  this._canvas.removeEventListener('touchend', this._handleTouchEnd);
 };
 
 SignaturePad.prototype.isEmpty = function () {
@@ -252,10 +260,6 @@ SignaturePad.prototype._handleMouseEvents = function () {
 };
 
 SignaturePad.prototype._handleTouchEvents = function () {
-  // Pass touch events to canvas element on mobile IE11 and Edge.
-  this._canvas.style.msTouchAction = 'none';
-  this._canvas.style.touchAction = 'none';
-
   this._canvas.addEventListener('touchstart', this._handleTouchStart);
   this._canvas.addEventListener('touchmove', this._handleTouchMove);
   this._canvas.addEventListener('touchend', this._handleTouchEnd);

--- a/src/signature_pad.js
+++ b/src/signature_pad.js
@@ -81,6 +81,7 @@ function SignaturePad(canvas, options) {
 
   if (this.supportsPointerEvents) {
     this._handlePointerDown = function (event) {
+      event.preventDefault();
       if (event.which === 1) {
         self._pointerDown = true;
         self._strokeBegin(event);
@@ -88,12 +89,14 @@ function SignaturePad(canvas, options) {
     };
 
     this._handlePointerMove = function (event) {
+      event.preventDefault();
       if (self._pointerDown) {
         self._strokeMoveUpdate(event);
       }
     };
 
     this._handlePointerUp = function (event) {
+      event.preventDefault();
       if (event.which === 1 && self._pointerDown) {
         self._pointerDown = false;
         self._strokeEnd(event);


### PR DESCRIPTION
It's a follow up of https://github.com/szimek/signature_pad/pull/281 with some fixes applied.

I haven't tested it on a device with stylus yet, because I don't have access to any :/

There's one small issue, not really related to pointer events though - mouse events will only be registered inside a canvas, but touch events will be registered outside of it as well, resulting in negative point coordinates :/