### PR TITLE
https://github.com/szimek/signature_pad/issues/309 Flush the throttled function as solution

### DIFF
--- a/src/signature_pad.js
+++ b/src/signature_pad.js
@@ -52,8 +52,6 @@ function SignaturePad(canvas, options) {
       self._mouseButtonDown = false;
       if (self._throttler) {
         self._throttler.flush();
-      } else {
-        self._strokeMoveUpdate();
       }
       self._strokeEnd(event);
     }
@@ -83,8 +81,6 @@ function SignaturePad(canvas, options) {
       event.preventDefault();
       if (self._throttler) {
         self._throttler.flush();
-      } else {
-        self._strokeMoveUpdate();
       }
       self._strokeEnd(event);
     }

--- a/src/throttle.js
+++ b/src/throttle.js
@@ -1,34 +1,51 @@
-/* eslint-disable */
-
-// http://stackoverflow.com/a/27078401/815507
-export default function throttle(func, wait, options) {
-  var context, args, result;
-  var timeout = null;
-  var previous = 0;
-  if (!options) options = {};
-  var later = function () {
-    previous = options.leading === false ? 0 : Date.now();
-    timeout = null;
-    result = func.apply(context, args);
-    if (!timeout) context = args = null;
+/* eslint-disable no-multi-assign, prefer-rest-params */
+function Throttler(func, wait, options) {
+  const self = this;
+  this._func = func;
+  this._wait = wait;
+  this._options = options;
+  if (!options) this._options = {};
+  this._later = function () {
+    self._previous = self._options.leading === false ? 0 : Date.now();
+    self._timeout = null;
+    const result = self._func.apply(self._context, self._args);
+    if (!self._timeout) self._context = self._args = null;
+    return result;
   };
-  return function () {
-    var now = Date.now();
-    if (!previous && options.leading === false) previous = now;
-    var remaining = wait - (now - previous);
-    context = this;
-    args = arguments;
-    if (remaining <= 0 || remaining > wait) {
-      if (timeout) {
-        clearTimeout(timeout);
-        timeout = null;
+
+  this.throttledFunction = function () {
+    const now = Date.now();
+    let result;
+    if (!self._previous && self._options.leading === false) self._previous = now;
+    const remaining = self._wait - (now - self._previous);
+    self._context = this;
+    self._args = arguments;
+    if (remaining <= 0 || remaining > self._wait) {
+      if (self._timeout) {
+        clearTimeout(self._timeout);
+        self._timeout = null;
       }
-      previous = now;
-      result = func.apply(context, args);
-      if (!timeout) context = args = null;
-    } else if (!timeout && options.trailing !== false) {
-      timeout = setTimeout(later, remaining);
+      self._previous = now;
+      result = self._func.apply(self._context, self._args);
+      if (!self._timeout) self._context = self._args = null;
+    } else if (!self._timeout && self._options.trailing !== false) {
+      self._timeout = setTimeout(self._later, remaining);
     }
     return result;
   };
 }
+
+Throttler.prototype.flush = function () {
+  let result;
+  if (this._timeout) {
+    clearTimeout(this._timeout);
+    this._timeout = null;
+    result = this._func.apply(this._context, this._args);
+    if (!this._timeout) this._context = this._args = null;
+  }
+
+  return result;
+};
+/* eslint-enable no-multi-spaces, space-in-parens */
+
+export default Throttler;


### PR DESCRIPTION
When drawing jjJJjj like in the bug report and the throttle function waits 16ms by default.
So, if you do a mouseUp when the throttle timeout is running, the last 15 ms could be appended to the next undo section. If you draw quick.
I've flushed the throttle function on mouseup or when touching ends.

see: https://github.com/szimek/signature_pad/issues/309