### PR TITLE
Pad size initialization

### DIFF
--- a/example/js/signature_pad.js
+++ b/example/js/signature_pad.js
@@ -113,6 +113,13 @@ function throttle(func, wait, options) {
 function SignaturePad(canvas, options) {
   var self = this;
   var opts = options || {};
+  
+  if (!canvas.attributes["width"] || !canvas.attributes["height"]) {
+    var ratio = Math.max(window.devicePixelRatio || 1, 1);
+    canvas.width = canvas.offsetWidth * ratio;
+    canvas.height = canvas.offsetHeight * ratio;
+    canvas.getContext("2d").scale(ratio, ratio);
+  }
 
   this.velocityFilterWeight = opts.velocityFilterWeight || 0.7;
   this.minWidth = opts.minWidth || 0.5;

--- a/src/signature_pad.js
+++ b/src/signature_pad.js
@@ -5,7 +5,14 @@ import throttle from './throttle';
 function SignaturePad(canvas, options) {
   const self = this;
   const opts = options || {};
-
+  
+  if (!canvas.attributes["width"] || !canvas.attributes["height"]) {
+    var ratio = Math.max(window.devicePixelRatio || 1, 1);
+    canvas.width = canvas.offsetWidth * ratio;
+    canvas.height = canvas.offsetHeight * ratio;
+    canvas.getContext("2d").scale(ratio, ratio);
+  }
+  
   this.velocityFilterWeight = opts.velocityFilterWeight || 0.7;
   this.minWidth = opts.minWidth || 0.5;
   this.maxWidth = opts.maxWidth || 2.5;


### PR DESCRIPTION
Ensure correct signature pad initialization if canvas size attributes are not provided but its style is changed (ex. via CSS) 
Closes #326 