### PR TITLE
Add current maxWidth in IPointGroup for correct undo drawing

### DIFF
--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -27,6 +27,7 @@ export interface IOptions {
 }
 
 export interface IPointGroup {
+  maxWidth: number;
   color: string;
   points: IBasicPoint[];
 }
@@ -230,6 +231,7 @@ export default class SignaturePad {
   private _strokeBegin(event: MouseEvent | Touch): void {
     const newPointGroup = {
       color: this.penColor,
+      maxWidth: this.maxWidth,
       points: [],
     };
 
@@ -429,7 +431,8 @@ export default class SignaturePad {
     drawDot: SignaturePad["_drawDot"],
   ): void {
     for (const group of pointGroups) {
-      const { color, points } = group;
+      const { maxWidth, color, points } = group;
+      this.maxWidth = maxWidth;
 
       if (points.length > 1) {
         for (let j = 0; j < points.length; j += 1) {

--- a/tests/fixtures/face.ts
+++ b/tests/fixtures/face.ts
@@ -4,6 +4,7 @@ export const dataURL = {
 };
 
 export const json = [{
+    "maxWidth": 2.5,
     "color": "black",
     "points": [{
       "time": 1523730547109,
@@ -12,6 +13,7 @@ export const json = [{
     }]
   },
   {
+    "maxWidth": 2.5,
     "color": "black",
     "points": [{
       "time": 1523730547775,
@@ -20,6 +22,7 @@ export const json = [{
     }]
   },
   {
+    "maxWidth": 2.5,
     "color": "black",
     "points": [{
         "time": 1523730548448,


### PR DESCRIPTION
In Undo example: https://jsfiddle.net/szimek/osenxvjc/
If pen's maxWidth is changed for each strokes, the final drawing of fromData() will all use the last stroke size.

**Solution:**
add current maxWidth to IPointGroup, and restore it for each saved stroke.