### PR TITLE
Retain images loaded with fromDataUrl.

### DIFF
--- a/example/js/signature_pad.js
+++ b/example/js/signature_pad.js
@@ -2,7 +2,7 @@
  * Signature Pad v2.3.2
  * https://github.com/szimek/signature_pad
  *
- * Copyright 2017 Szymon Nowak
+ * Copyright 2018 Szymon Nowak
  * Released under the MIT license
  *
  * The main idea and some parts of the code (e.g. drawing variable width Bézier curve) are taken from:
@@ -210,9 +210,8 @@ SignaturePad.prototype.fromDataURL = function (dataUrl) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
   var image = new Image();
-  var ratio = options.ratio || window.devicePixelRatio || 1;
-  var width = options.width || this._canvas.width / ratio;
-  var height = options.height || this._canvas.height / ratio;
+  var width = options.width || this._canvas.width;
+  var height = options.height || this._canvas.height;
 
   this._reset();
   image.src = dataUrl;
@@ -220,6 +219,7 @@ SignaturePad.prototype.fromDataURL = function (dataUrl) {
     _this._ctx.drawImage(image, 0, 0, width, height);
   };
   this._isEmpty = false;
+  this._originalImage = dataUrl;
 };
 
 SignaturePad.prototype.toDataURL = function (type) {
@@ -246,7 +246,7 @@ SignaturePad.prototype.off = function () {
   // Pass touch events to canvas element on mobile IE11 and Edge.
   this._canvas.style.msTouchAction = 'auto';
   this._canvas.style.touchAction = 'auto';
-  
+
   this._canvas.removeEventListener('mousedown', this._handleMouseDown);
   this._canvas.removeEventListener('mousemove', this._handleMouseMove);
   document.removeEventListener('mouseup', this._handleMouseUp);
@@ -533,15 +533,25 @@ SignaturePad.prototype._toSVG = function () {
 
   var pointGroups = this._data;
   var canvas = this._canvas;
-  var ratio = Math.max(window.devicePixelRatio || 1, 1);
   var minX = 0;
   var minY = 0;
-  var maxX = canvas.width / ratio;
-  var maxY = canvas.height / ratio;
+  var maxX = canvas.width;
+  var maxY = canvas.height;
   var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
 
   svg.setAttributeNS(null, 'width', canvas.width);
   svg.setAttributeNS(null, 'height', canvas.height);
+
+  // Set the originally loaded image into th SVG.
+  if (this._originalImage) {
+    var original = document.createElement('image');
+    original.setAttribute('x', '0');
+    original.setAttribute('y', '0');
+    original.setAttribute('width', canvas.width);
+    original.setAttribute('height', canvas.height);
+    original.setAttribute('xlink:href', this._originalImage);
+    svg.appendChild(original);
+  }
 
   this._fromData(pointGroups, function (curve, widths, color) {
     var path = document.createElement('path');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "signature_pad",
   "description": "Library for drawing smooth signatures.",
-  "version": "2.3.2",
+  "version": "2.3.2-peritus-1.0.1",
   "homepage": "https://github.com/szimek/signature_pad",
   "author": {
     "name": "Szymon Nowak",

--- a/src/signature_pad.js
+++ b/src/signature_pad.js
@@ -108,6 +108,7 @@ SignaturePad.prototype.fromDataURL = function (dataUrl, options = {}) {
     this._ctx.drawImage(image, 0, 0, width, height);
   };
   this._isEmpty = false;
+  this._originalImage = dataUrl;
 };
 
 SignaturePad.prototype.toDataURL = function (type, ...options) {
@@ -422,6 +423,17 @@ SignaturePad.prototype._toSVG = function () {
 
   svg.setAttributeNS(null, 'width', canvas.width);
   svg.setAttributeNS(null, 'height', canvas.height);
+
+  // Set the originally loaded image into th SVG.
+  if (this._originalImage) {
+    const original = document.createElement('image');
+    original.setAttribute('x', '0');
+    original.setAttribute('y', '0');
+    original.setAttribute('width', canvas.width);
+    original.setAttribute('height', canvas.height);
+    original.setAttribute('href', this._originalImage);
+    svg.appendChild(original);
+  }
 
   this._fromData(
     pointGroups,

--- a/src/signature_pad.js
+++ b/src/signature_pad.js
@@ -98,9 +98,8 @@ SignaturePad.prototype.clear = function () {
 
 SignaturePad.prototype.fromDataURL = function (dataUrl, options = {}) {
   const image = new Image();
-  const ratio = options.ratio || window.devicePixelRatio || 1;
-  const width = options.width || (this._canvas.width / ratio);
-  const height = options.height || (this._canvas.height / ratio);
+  const width = options.width || this._canvas.width;
+  const height = options.height || this._canvas.height;
 
   this._reset();
   image.src = dataUrl;
@@ -414,11 +413,10 @@ SignaturePad.prototype._fromData = function (pointGroups, drawCurve, drawDot) {
 SignaturePad.prototype._toSVG = function () {
   const pointGroups = this._data;
   const canvas = this._canvas;
-  const ratio = Math.max(window.devicePixelRatio || 1, 1);
   const minX = 0;
   const minY = 0;
-  const maxX = canvas.width / ratio;
-  const maxY = canvas.height / ratio;
+  const maxX = canvas.width;
+  const maxY = canvas.height;
   const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
 
   svg.setAttributeNS(null, 'width', canvas.width);
@@ -431,7 +429,7 @@ SignaturePad.prototype._toSVG = function () {
     original.setAttribute('y', '0');
     original.setAttribute('width', canvas.width);
     original.setAttribute('height', canvas.height);
-    original.setAttribute('href', this._originalImage);
+    original.setAttribute('xlink:href', this._originalImage);
     svg.appendChild(original);
   }
 


### PR DESCRIPTION
Plugs a small gap  with `fromDataUrl` and `toDataUrl`, allowing them to work like `fromData` and `toData`, although it doesn't populate the internal point structure so `toData` wont include the image, but I guess most people use either one format or the other.