### PR TITLE
prevent drawCurve exceeding max width

### DIFF
--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -435,7 +435,7 @@ export default class SignaturePad {
       y += 3 * u * tt * curve.control2.y;
       y += ttt * curve.endPoint.y;
 
-      const width = curve.startWidth + ttt * widthDelta;
+      const width = Math.min(curve.startWidth + ttt * widthDelta, this.maxWidth);
       this._drawCurveSegment(x, y, width);
     }
 


### PR DESCRIPTION
When fast drawing with thicker line settings like `minWidth: 2, maxWidth: 4, velocityFilterWeight: 0.9` big inkt drop are showing on the canvas. It happens mostly around on the corners and start of new lines.

![image](https://user-images.githubusercontent.com/6724749/47843064-c7c68100-ddbe-11e8-947a-d73b7bc4e4fb.png)
