### PR TITLE
Use mjs instead of m.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "source": "src/signature_pad.ts",
   "dev:main": "dist/signature_pad.js",
   "main": "dist/signature_pad.min.js",
-  "module": "dist/signature_pad.m.js",
+  "module": "dist/signature_pad.mjs",
   "umd:main": "dist/signature_pad.umd.js",
   "types": "dist/types/signature_pad.d.ts",
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -105,7 +105,7 @@ export default [
       }),
     ],
     output: {
-      file: 'dist/signature_pad.m.js',
+      file: 'dist/signature_pad.mjs',
       format: 'es',
       banner,
     },
@@ -123,7 +123,7 @@ export default [
       terser(),
     ],
     output: {
-      file: 'dist/signature_pad.m.min.js',
+      file: 'dist/signature_pad.min.mjs',
       format: 'es',
       banner,
     },


### PR DESCRIPTION
refs: 

* https://github.com/nodejs/node-eps/blob/master/002-es-modules.md#32-determining-if-source-is-an-es-module
* https://developers.google.com/web/fundamentals/primers/modules

mjs extention might be better for ES Module extention. what do you think? 