### PR TITLE
Set SVG viewBox size from canvas width and height without factoring by devicePixelDensity

### DIFF
--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -563,7 +563,7 @@ export default class SignaturePad {
       '<svg' +
       ' xmlns="http://www.w3.org/2000/svg"' +
       ' xmlns:xlink="http://www.w3.org/1999/xlink"' +
-      ` viewBox="${minX} ${minY} ${maxX} ${maxY}"` +
+      ` viewBox="${minX} ${minY} ${this.canvas.width} ${this.canvas.height}"` +
       ` width="${maxX}"` +
       ` height="${maxY}"` +
       '>';


### PR DESCRIPTION
There is currently an issue in the export of SVGs that causes data to be truncated off the right-hand and bottom.

The problem lies in the fact that stroke data is being recorded in terms of the overall size of the canvas and then the size of the viewBox is being reduced afterwards. It's not necessary to reduce the viewBox's size because the viewBox's width and height are unitless and only meaningful in relation to the stroke data. Reducing the maxX of the viewBox from 1000 to 500, for example, just invalidates coordinates with x > 500 because they no longer exist in the viewBox.

I think the intent of this originally must have been to preserve the dimensions of the image across devices of differing DPI, and for that we only need to adjust the width and height attributes.