### PR TITLE
fixing split error

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Here's an example in C# for ASP.NET:
 
 ``` csharp
 var dataUri = "data:image/png;base64,iVBORw0K...";
-var encodedImage = dataUri.Split(",")[1];            
+var encodedImage = dataUri.Split(',')[1];            
 var decodedImage = Convert.FromBase64String(encodedImage);
 System.IO.File.WriteAllBytes("signature.png", decodedImage);
 ```


### PR DESCRIPTION
using "" instead '' in split will lead to an error :" cannot convert from string to char"