### PR TITLE
add processing when lastPointGroup is undefined

### DIFF
--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -277,13 +277,13 @@ export default class SignaturePad {
 
     const point = this._createPoint(x, y);
     const lastPointGroup = this._data[this._data.length - 1];
-    const lastPoints = lastPointGroup.points;
+    const lastPoints = lastPointGroup ? lastPointGroup.points : [];
     const lastPoint =
       lastPoints.length > 0 && lastPoints[lastPoints.length - 1];
     const isLastPointTooClose = lastPoint
       ? point.distanceTo(lastPoint) <= this.minDistance
       : false;
-    const color = lastPointGroup.color;
+    const color = lastPointGroup ? lastPointGroup.color : this.penColor;
 
     // Skip this point if it's too close to the previous one
     if (!lastPoint || !(lastPoint && isLastPointTooClose)) {


### PR DESCRIPTION
I get an error when I clear the mouse up.
this is example.

```typescript
const Drawing: FC<{}> = ({}) => {
  const canvas = useRef<HTMLCanvasElement>(null)
  const [pad, setPad] = useState<SignaturePad | null>(null)
  const handleMouseUp = useCallback(
    (e: MouseEvent<HTMLElement>) => {
      if (!pad || !pad.toDataURL || !pad.clear) return
      const svg: string = pad.toDataURL('image/svg+xml')
      pad.clear()
    },
    [pad]
  )

  useEffect(() => {
    if (!canvas || !canvas.current) return
    setPad(
      new SignaturePad(canvas.current, {
        backgroundColor: 'rgb(255, 255, 255)'
      })
    )
  }, [canvas.current])

  return (
      <Canvas
        ref={canvas}
        onMouseUp={handleMouseUp}
        width={window.innerWidth * 0.8}
        height={window.innerHeight * 0.8}
      />
  )
}
```

<img width="426" alt="スクリーンショット 2019-03-17 11 58 56" src="https://user-images.githubusercontent.com/30266990/54484545-2bec6c00-48ac-11e9-994a-dc3e3cce91d3.png">
