### PR TITLE
fix: use first touch when there're multi touchStart

### DIFF
--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -231,7 +231,7 @@ export default class SignaturePad {
     // Prevent scrolling.
     event.preventDefault();
 
-    if (event.targetTouches.length === 1) {
+    if (event.targetTouches.length > 0) {
       const touch = event.changedTouches[0];
       this._strokeBegin(touch);
     }


### PR DESCRIPTION
On mobile devices, users can touch with two fingers.If two fingers touch the canvas in the meantime, _strokeUpdate will throw error: 
```
private _strokeUpdate(event: MouseEvent | Touch): void {
    const x = event.clientX;
    const y = event.clientY;

    const point = this._createPoint(x, y);
    const lastPointGroup = this._data[this._data.length - 1];
    const lastPoints = lastPointGroup.points;
```
![image](https://user-images.githubusercontent.com/6389571/55861375-d6ecfe80-5ba8-11e9-839a-5a02a7078b53.png)
Because `this._data` only push new point group when `_strokeBegin`, however `_handleTouchStart` checks `event.targetTouches.length`,  only when the length === 1,` _strokeBegin` triggers, so I changed the check code, `_strokeBegin` shall trigger when touched and runs with the first touch event.