### PR TITLE
Allow disabling event handlers in the constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ signaturePad.on();
 <dd>(string) Color used to draw the lines. Can be any color format accepted by <code>context.fillStyle</code>. Defaults to <code>"black"</code>.</dd>
 <dt>velocityFilterWeight</dt>
 <dd>(float) Weight used to modify new velocity based on the previous velocity. Defaults to <code>0.7</code>.</dd>
+<dt>off</dt>
+<dd>(boolean) Do not all event handlers. Defaults to <code>false</code>.</dd>
 <dt>onBegin</dt>
 <dd>(function) Callback when stroke begin.</dd>
 <dt>onEnd</dt>

--- a/docs/js/signature_pad.umd.js
+++ b/docs/js/signature_pad.umd.js
@@ -1,6 +1,6 @@
 /*!
  * Signature Pad v3.0.0-beta.3 | https://github.com/szimek/signature_pad
- * (c) 2018 Szymon Nowak | Released under the MIT license
+ * (c) 2019 Szymon Nowak | Released under the MIT license
  */
 
 (function (global, factory) {
@@ -202,6 +202,9 @@
           this.onEnd = options.onEnd;
           this._ctx = canvas.getContext('2d');
           this.clear();
+          if (options.off || false) {
+              return;
+          }
           this.on();
       }
       SignaturePad.prototype.clear = function () {
@@ -417,7 +420,7 @@
               y += 3 * uu * t * curve.control1.y;
               y += 3 * u * tt * curve.control2.y;
               y += ttt * curve.endPoint.y;
-              var width = curve.startWidth + ttt * widthDelta;
+              var width = Math.min(curve.startWidth + ttt * widthDelta, this.maxWidth);
               this._drawCurveSegment(x, y, width);
           }
           ctx.closePath();

--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -29,6 +29,7 @@ export interface IOptions {
   penColor?: string;
   throttle?: number;
   velocityFilterWeight?: number;
+  off?: boolean;
   onBegin?: (event: MouseEvent | Touch) => void;
   onEnd?: (event: MouseEvent | Touch) => void;
 }
@@ -97,6 +98,9 @@ export default class SignaturePad {
     this._ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
     this.clear();
 
+    if (options.off || false) {
+      return;
+    }
     // Enable mouse and touch event handlers
     this.on();
   }
@@ -435,7 +439,10 @@ export default class SignaturePad {
       y += 3 * u * tt * curve.control2.y;
       y += ttt * curve.endPoint.y;
 
-      const width = Math.min(curve.startWidth + ttt * widthDelta, this.maxWidth);
+      const width = Math.min(
+        curve.startWidth + ttt * widthDelta,
+        this.maxWidth,
+      );
       this._drawCurveSegment(x, y, width);
     }
 


### PR DESCRIPTION
Skipping the `on()` function allows me to use the [node canvas](https://github.com/Automattic/node-canvas) library to generate images from JSON on the server.

Something like this:

```js
const fs = require('fs')
const { createCanvas } = require('canvas')
const SignaturePad = require('signature_pad')
const canvas = createCanvas(200, 200)

let signaturePad = new SignaturePad(canvas, { off: true })
signaturePad.fromData(data)

const out = fs.createWriteStream('./test.png')
const stream = canvas.createPNGStream()
stream.pipe(out)
out.on('finish', () =>  console.log('The signature was written to a PNG file'))
```