### PR TITLE
Added toFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ signaturePad.toDataURL(); // save image as PNG
 signaturePad.toDataURL("image/jpeg"); // save image as JPEG
 signaturePad.toDataURL("image/svg+xml"); // save image as SVG
 
+// Add to FormData directly
+signaturePad.toFile().then(function (file) {
+  formData.append("signature", file);
+});
+
 // Draws signature image from data URL.
 // NOTE: This method does not populate internal data structure that represents drawn signature. Thus, after using #fromDataURL, #toData won't work properly.
 signaturePad.fromDataURL("data:image/png;base64,iVBORw0K...");

--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -151,6 +151,10 @@ export default class SignaturePad {
         return this.canvas.toDataURL(type, encoderOptions);
     }
   }
+  
+  public toFile(filename = "signature.png") {
+    return new File([this.canvas.toBlob()], filename);
+  }
 
   public on(): void {
     // Disable panning/zooming when touching canvas element

--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -154,7 +154,7 @@ export default class SignaturePad {
   
   public toFile(filename = "signature.png", mime = "image/png", quality = 0.8) {
     return new Promise((resolve) => {
-      this.canvas.toBlob(function (blob) {
+      this.canvas.toBlob(function (blob: Blob) {
         resolve(new File([blob], filename));
       }, mime, quality);
     });

--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -152,8 +152,12 @@ export default class SignaturePad {
     }
   }
   
-  public toFile(filename = "signature.png") {
-    return new File([this.canvas.toBlob()], filename);
+  public toFile(filename = "signature.png", mime = "image/png", quality = 0.8) {
+    return new Promise(() => {
+      this.canvas.toBlob(function (blob) {
+        resolve(new File([blob], filename));
+      }, mime, quality);
+    });
   }
 
   public on(): void {

--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -153,7 +153,7 @@ export default class SignaturePad {
   }
   
   public toFile(filename = "signature.png", mime = "image/png", quality = 0.8) {
-    return new Promise(() => {
+    return new Promise((resolve) => {
       this.canvas.toBlob(function (blob) {
         resolve(new File([blob], filename));
       }, mime, quality);


### PR DESCRIPTION
Using the toFile method you can easily attach the signature to a FormData instance and avoid parsing.