### PR TITLE
Added functionality similar to addFromData from v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ const data = signaturePad.toData();
 // Draws signature image from an array of point groups
 signaturePad.fromData(data);
 
+// Draws signature image from an array of point groups, without clearing your existing image
+signaturePad.addFromData(data);
+
 // Clears the canvas
 signaturePad.clear();
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ const data = signaturePad.toData();
 // Draws signature image from an array of point groups
 signaturePad.fromData(data);
 
-// Draws signature image from an array of point groups, without clearing your existing image
-signaturePad.addFromData(data);
+// Draws signature image from an array of point groups, without clearing your existing image (second parameter defaults to true if null)
+signaturePad.fromData(data, false);
 
 // Clears the canvas
 signaturePad.clear();

--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -190,26 +190,17 @@ export default class SignaturePad {
     return this._isEmpty;
   }
 
-  public fromData(pointGroups: IPointGroup[]): void {
-    this.clear();
+  public fromData(pointGroups: IPointGroup[], clear: boolean = true): void {
+    if (clear) {
+      this.clear();
+    }
 
     this._fromData(
       pointGroups,
       ({ color, curve }) => this._drawCurve({ color, curve }),
       ({ color, point }) => this._drawDot({ color, point }),
     );
-
-    this._data = pointGroups;
-  }
-
-  public addFromData(pointGroups: IPointGroup[]): void {
-    this._fromData(
-      pointGroups,
-      ({ color, curve }) => this._drawCurve({ color, curve }),
-      ({ color, point }) => this._drawDot({ color, point }),
-    );
-
-    this._data.concat(pointGroups);
+    this._data = clear ? pointGroups : this._data.concat(pointGroups);
   }
 
   public toData(): IPointGroup[] {

--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -202,6 +202,16 @@ export default class SignaturePad {
     this._data = pointGroups;
   }
 
+  public addFromData(pointGroups: IPointGroup[]): void {
+    this._fromData(
+      pointGroups,
+      ({ color, curve }) => this._drawCurve({ color, curve }),
+      ({ color, point }) => this._drawDot({ color, point }),
+    );
+
+    this._data.concat(pointGroups);
+  }
+
   public toData(): IPointGroup[] {
     return this._data;
   }


### PR DESCRIPTION
This change adds the "addFromData" function, which adds points to the SignaturePad without clearing the canvas first. This feature existed in v2.