### PR TITLE
Fix #480 - Fix race condition / edge case in _strokeUpdate where this._data can sometimes be []

### DIFF
--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -265,6 +265,13 @@ export default class SignaturePad {
   }
 
   private _strokeUpdate(event: MouseEvent | Touch): void {
+    if (this._data.length === 0) {
+      // This can happen if clear() was called while a signature is still in progress,
+      // or if there is a race condition between start/update events.
+      this._strokeBegin(event)
+      return
+    }
+
     const x = event.clientX;
     const y = event.clientY;
 


### PR DESCRIPTION
Fixes #480 

Fixes this error that I'm getting sometimes:

<img width="947" alt="Screen Shot 2020-04-28 at 10 09 48 PM" src="https://user-images.githubusercontent.com/139536/80497405-fa920b00-899c-11ea-9027-4ad3202a5115.png">

This can happen if `clear()` is called while a signature is still being drawn, so the signature might need to be "restarted" by calling `_strokeBegin` again.