### PR TITLE
Fix(msTouch)

### DIFF
--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -15,7 +15,7 @@ import { throttle } from './throttle';
 
 declare global {
   interface CSSStyleDeclaration {
-    msTouchAction: string;
+    msTouchAction: string | null;
   }
 }
 


### PR DESCRIPTION
Fix Error Below: 
14:9 Subsequent property declarations must have the same type.  Property 'msTouchAction' must be of type 'string | null', but here has type 'string'.
    12 | declare global {
    13 |     interface CSSStyleDeclaration {
  > 14 |         msTouchAction: string;
       |         ^
    15 |     }
    16 | }
    17 | export interface Options {

