### PR TITLE
fix _drawCurve() when moving very slowly

### DIFF
--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -419,7 +419,7 @@ export default class SignaturePad {
     const widthDelta = curve.endWidth - curve.startWidth;
     // '2' is just an arbitrary number here. If only lenght is used, then
     // there are gaps between curve segments :/
-    const drawSteps = Math.floor(curve.length()) * 2;
+    const drawSteps = curve.length() * 2;
 
     ctx.beginPath();
     ctx.fillStyle = color;

--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -419,7 +419,7 @@ export default class SignaturePad {
     const widthDelta = curve.endWidth - curve.startWidth;
     // '2' is just an arbitrary number here. If only lenght is used, then
     // there are gaps between curve segments :/
-    const drawSteps = curve.length() * 2;
+    const drawSteps = Math.ceil(curve.length()) * 2;
 
     ctx.beginPath();
     ctx.fillStyle = color;


### PR DESCRIPTION
On Android devices, curve.length() may return a number less than 1.
In other words, if you write a line very very slowly, 
Math.floor() will set the length of the line to 0.
This leads to a bug where the line is not written at all.
This bug can be solved by not using Math.floor().
