### PR TITLE
Use touch events for iOS platforms instead of point events

### DIFF
--- a/docs/js/signature_pad.umd.js
+++ b/docs/js/signature_pad.umd.js
@@ -139,7 +139,6 @@
         constructor(canvas, options = {}) {
             super();
             this.canvas = canvas;
-            this.options = options;
             this._handleMouseDown = (event) => {
                 if (event.buttons === 1) {
                     this._drawningStroke = true;
@@ -252,7 +251,8 @@
         on() {
             this.canvas.style.touchAction = 'none';
             this.canvas.style.msTouchAction = 'none';
-            if (window.PointerEvent) {
+            const isIOS = /Macintosh/.test(navigator.userAgent) && 'ontouchstart' in document;
+            if (window.PointerEvent && !isIOS) {
                 this._handlePointerEvents();
             }
             else {

--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -68,7 +68,7 @@ export default class SignaturePad extends EventTarget {
 
   constructor(
     private canvas: HTMLCanvasElement,
-    private options: Options = {},
+    options: Options = {},
   ) {
     super();
     this.velocityFilterWeight = options.velocityFilterWeight || 0.7;
@@ -154,7 +154,11 @@ export default class SignaturePad extends EventTarget {
     this.canvas.style.touchAction = 'none';
     this.canvas.style.msTouchAction = 'none';
 
-    if (window.PointerEvent) {
+    const isIOS =/Macintosh/.test(navigator.userAgent) && 'ontouchstart' in document;
+
+    // The "Scribble" feature of iOS intercepts point events. So that we can lose some of them when tapping rapidly. 
+    // Use touch events for iOS platforms to prevent it. See https://developer.apple.com/forums/thread/664108 for more information.
+    if (window.PointerEvent && !isIOS) {
       this._handlePointerEvents();
     } else {
       this._handleMouseEvents();


### PR DESCRIPTION
The "Scribble" feature of iOS intercepts point events. So that we can lose some of them when tapping rapidly. We should use touch events for iOS platforms according to https://developer.apple.com/forums/thread/664108 and https://stackoverflow.com/questions/64314226/ipados-14-apple-pencil-fast-tapping-not-working-html-javascript-ontouchstart/64316781#64316781.
I've tested this solution on iPad Air 2020 with Apple Pencil. It works right.

closes #518 