### PR TITLE
updated script tag example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yarn add signature_pad
 
 You can also add it directly to your page using `<script>` tag:
 ```html
-<script src="https://cdn.jsdelivr.net/npm/signature_pad@2.3.2/dist/signature_pad.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/signature_pad@4.0.0/dist/signature_pad.umd.min.js"></script>
 ```
 You can select a different version at [https://www.jsdelivr.com/package/npm/signature_pad](https://www.jsdelivr.com/package/npm/signature_pad).
 


### PR DESCRIPTION
Hi,

A made a small change to the readme.

I noticed that the readme has examples (to be specific addEventListener) which assume you are using v4 of the signature pad. 

However the script tag was still including v2. 

Cheers