### PR TITLE
mouseleave / touchleave events

### DIFF
--- a/docs/js/signature_pad.umd.js
+++ b/docs/js/signature_pad.umd.js
@@ -270,10 +270,12 @@
             document.removeEventListener('pointerup', this._handlePointerEnd);
             this.canvas.removeEventListener('mousedown', this._handleMouseDown);
             this.canvas.removeEventListener('mousemove', this._handleMouseMove);
+            this.canvas.removeEventListener('mouseleave', this._handleMouseUp);
             document.removeEventListener('mouseup', this._handleMouseUp);
             this.canvas.removeEventListener('touchstart', this._handleTouchStart);
             this.canvas.removeEventListener('touchmove', this._handleTouchMove);
             this.canvas.removeEventListener('touchend', this._handleTouchEnd);
+            this.canvas.removeEventListener('touchleave', this._handleTouchEnd);
         }
         isEmpty() {
             return this._isEmpty;
@@ -363,12 +365,14 @@
             this._drawningStroke = false;
             this.canvas.addEventListener('mousedown', this._handleMouseDown);
             this.canvas.addEventListener('mousemove', this._handleMouseMove);
+            this.canvas.addEventListener('mouseleave', this._handleMouseUp);
             document.addEventListener('mouseup', this._handleMouseUp);
         }
         _handleTouchEvents() {
             this.canvas.addEventListener('touchstart', this._handleTouchStart);
             this.canvas.addEventListener('touchmove', this._handleTouchMove);
             this.canvas.addEventListener('touchend', this._handleTouchEnd);
+            this.canvas.addEventListener('touchleave', this._handleTouchEnd);
         }
         _reset() {
             this._lastPoints = [];

--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -180,11 +180,13 @@ export default class SignaturePad extends EventTarget {
 
     this.canvas.removeEventListener('mousedown', this._handleMouseDown);
     this.canvas.removeEventListener('mousemove', this._handleMouseMove);
-    document.removeEventListener('mouseup', this._handleMouseUp);
+    this.canvas.removeEventListener('mouseup', this._handleMouseUp);
+    document.removeEventListener('mouseleave', this._handleMouseUp);
 
     this.canvas.removeEventListener('touchstart', this._handleTouchStart);
     this.canvas.removeEventListener('touchmove', this._handleTouchMove);
     this.canvas.removeEventListener('touchend', this._handleTouchEnd);
+    this.canvas.removeEventListener('touchleave', this._handleTouchEnd);
   }
 
   public isEmpty(): boolean {
@@ -381,6 +383,7 @@ export default class SignaturePad extends EventTarget {
 
     this.canvas.addEventListener('mousedown', this._handleMouseDown);
     this.canvas.addEventListener('mousemove', this._handleMouseMove);
+    this.canvas.addEventListener('mouseup', this._handleMouseUp);
     document.addEventListener('mouseup', this._handleMouseUp);
   }
 
@@ -388,6 +391,7 @@ export default class SignaturePad extends EventTarget {
     this.canvas.addEventListener('touchstart', this._handleTouchStart);
     this.canvas.addEventListener('touchmove', this._handleTouchMove);
     this.canvas.addEventListener('touchend', this._handleTouchEnd);
+    this.canvas.addEventListener('touchleave', this._handleTouchEnd);
   }
 
   // Called when a new line is started


### PR DESCRIPTION
In our application, we pop up a modal dialog that has a canvas to capture a signature. If you are drawing, the canvas is appropriately updated but if you drag the signature _off_ of the canvas, the `mouseup` event does _not_ fire, therefor the `strokeEnd` end does not _either_.

This does *not* appear to be an issue with your demo, so I'm unsure of the nuance as to why this is a problem for us, but locally if I did the following:

* do a `canvas.addEventListener('mouseleave', onEndStroke)` on the `beginStroke` event
* on my `onEndStroke` handler, added a `canvas.removeEventListener('mouseleave', onEndStroke)`

Our problem goes away. This PR is to codify that same behavior in the upstream so we only have to then subscribe to `beginStroke` / `endStroke` events (rather than adding our own event handler here).