### PR TITLE
fix fast double-tap on iOS 15

### DIFF
--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -87,6 +87,10 @@ export default class SignaturePad extends SignatureEventTarget {
 
     this.clear();
 
+    // Disable panning/zooming when touching canvas element
+    this.canvas.style.touchAction = 'none';
+    this.canvas.style.msTouchAction = 'none';
+
     // Enable mouse and touch event handlers
     this.on();
   }
@@ -148,10 +152,6 @@ export default class SignaturePad extends SignatureEventTarget {
   }
 
   public on(): void {
-    // Disable panning/zooming when touching canvas element
-    this.canvas.style.touchAction = 'none';
-    this.canvas.style.msTouchAction = 'none';
-
     const isIOS =
       /Macintosh/.test(navigator.userAgent) && 'ontouchstart' in document;
 
@@ -169,10 +169,6 @@ export default class SignaturePad extends SignatureEventTarget {
   }
 
   public off(): void {
-    // Enable panning/zooming when touching canvas element
-    this.canvas.style.touchAction = 'auto';
-    this.canvas.style.msTouchAction = 'auto';
-
     this.canvas.removeEventListener('pointerdown', this._handlePointerStart);
     this.canvas.removeEventListener('pointermove', this._handlePointerMove);
     document.removeEventListener('pointerup', this._handlePointerEnd);


### PR DESCRIPTION
On iOS 15, a fast double-tap will trigger an unintended pan event.
I think this is a problem caused by the loupe feature in iOS 15.
It does not occur in iOS 14.
The solution is to always turn off the pan event in the constructor,
instead of switching it in event handling.
I think there is no need to turn the pan event on/off.
Therefore, it is better to stop the pan event in the constructor
so that it is not affected by the browser implementation.

I have checked this patch on the following environments.
- iPhone 8 (iOS 15.1) + Safari    # need fixing
- iPhone 8 (iOS 14.8.1) + Safari  # not need fixing
- MediaPad M3 Lite 10 wp (Android 7.0) + Chrome  # not need fixing
I don't have Windows tablet, so I can't check ms-touch-action,
but theoretically it should work.

https://user-images.githubusercontent.com/28778641/149785412-9f370aaf-d329-4a51-84bd-6bd235f446fe.mp4
