### PR TITLE
Fix race condition / edge case in _strokeUpdate where this._data can sometimes be []

### DIFF
--- a/src/signature_pad.js
+++ b/src/signature_pad.js
@@ -154,6 +154,13 @@ SignaturePad.prototype._strokeBegin = function (event) {
 };
 
 SignaturePad.prototype._strokeUpdate = function (event) {
+  if (this._data.length === 0) {
+      // This can happen if clear() was called while a signature is still in progress,
+      // or if there is a race condition between start/update events.
+      this._strokeBegin(event)
+      return
+  }
+  
   const x = event.clientX;
   const y = event.clientY;
 


### PR DESCRIPTION
Replicates https://github.com/szimek/signature_pad/pull/481/ but into v2 branch.

There are other libraries that depend upon older versions of this library and may not want to carry out refactoring to upgrade through 2 major versions to receive this fix.

An example is discussed here https://github.com/agilgur5/react-signature-canvas/pull/68

As the fix is very simple, and maps exactly from v4 back to v2, I am proposing this is merged and a new minor or point release of v2 is cut to include it.