### PR TITLE
fix: don't mutate data in `fromData`, clone instead

### DIFF
--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -206,7 +206,7 @@ export default class SignaturePad extends SignatureEventTarget {
       this._drawDot.bind(this),
     );
 
-    this._data = clear ? pointGroups : this._data.concat(pointGroups);
+    this._data = this._data.concat(pointGroups);
   }
 
   public toData(): PointGroup[] {


### PR DESCRIPTION
## Summary

always clone the input data in `fromData` so that the input is not mutated

## Description

- in the clear case, `fromData` would set `this._data = pointGroups`,
  which made the pointer the same as the one for the parameter
  - as `this._data` is internally mutated, this would cause the input
    parameter to also be mutated as a side-effect

- this input mutation side-effect is likely unintended, so patched it so
  that the data is cloned in _all_ cases, not only in the append case
  - in the clear case, `this._data` is set to an empty array by
    `this.clear()`, so this is equivalent to `[].concat(pointGroups)`,
    which will result in them all being cloned
    
 ## Misc Notes
 
Fixes https://github.com/agilgur5/react-signature-canvas/issues/56
Credits to @Zwyx for discovering this in the above issue

Can see that issue for some manual testing I did around this cloning as well as how I found the bug here