### PR TITLE
docs: add options to `fromDataURL` (and `toDataURL`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,30 +10,39 @@ It works in all modern desktop and mobile browsers and doesn't depend on any ext
 [Demo](http://szimek.github.io/signature_pad) works in desktop and mobile browsers. You can check out its [source code](https://github.com/szimek/signature_pad/blob/gh-pages/js/app.js) for some tips on how to handle window resize and high DPI screens. You can also find more about the latter in [HTML5 Rocks tutorial](http://www.html5rocks.com/en/tutorials/canvas/hidpi).
 
 ### Other demos
+
 - Erase feature: <https://jsfiddle.net/szimek/jq9cyzuc/>
 - Undo feature: <https://jsfiddle.net/szimek/osenxvjc/>
 
 ## Installation
+
 You can install the latest release using npm:
+
 ```bash
 npm install --save signature_pad
 ```
+
 or Yarn:
+
 ```bash
 yarn add signature_pad
 ```
 
 You can also add it directly to your page using `<script>` tag:
+
 ```html
 <script src="https://cdn.jsdelivr.net/npm/signature_pad@4.0.0/dist/signature_pad.umd.min.js"></script>
 ```
+
 You can select a different version at [https://www.jsdelivr.com/package/npm/signature_pad](https://www.jsdelivr.com/package/npm/signature_pad).
 
 This library is provided as UMD (Universal Module Definition) and ES6 module.
 
 ## Usage
+
 ### API
-``` javascript
+
+```javascript
 const canvas = document.querySelector("canvas");
 
 const signaturePad = new SignaturePad(canvas);
@@ -41,11 +50,15 @@ const signaturePad = new SignaturePad(canvas);
 // Returns signature image as data URL (see https://mdn.io/todataurl for the list of possible parameters)
 signaturePad.toDataURL(); // save image as PNG
 signaturePad.toDataURL("image/jpeg"); // save image as JPEG
+signaturePad.toDataURL("image/jpeg", 0.5); // save image as JPEG with 0.5 image quality
 signaturePad.toDataURL("image/svg+xml"); // save image as SVG
 
-// Draws signature image from data URL.
+// Draws signature image from data URL (mostly uses https://mdn.io/drawImage under-the-hood)
 // NOTE: This method does not populate internal data structure that represents drawn signature. Thus, after using #fromDataURL, #toData won't work properly.
 signaturePad.fromDataURL("data:image/png;base64,iVBORw0K...");
+
+// Draws signature image from data URL and alters it with the given options
+signaturePad.fromDataURL("data:image/png;base64,iVBORw0K...", { ratio: 1, width: 400, height: 200, xOffset: 100, yOffset: 50 });
 
 // Returns signature image as an array of point groups
 const data = signaturePad.toData();
@@ -70,6 +83,7 @@ signaturePad.on();
 ```
 
 ### Options
+
 <dl>
 <dt>dotSize</dt>
 <dd>(float or function) Radius of a single dot.</dd>
@@ -90,6 +104,7 @@ signaturePad.on();
 </dl>
 
 You can set options during initialization:
+
 ```javascript
 const signaturePad = new SignaturePad(canvas, {
     minWidth: 5,
@@ -97,7 +112,9 @@ const signaturePad = new SignaturePad(canvas, {
     penColor: "rgb(66, 133, 244)"
 });
 ```
+
 or during runtime:
+
 ```javascript
 const signaturePad = new SignaturePad(canvas);
 signaturePad.minWidth = 5;
@@ -106,6 +123,7 @@ signaturePad.penColor = "rgb(66, 133, 244)";
 ```
 
 ### Events
+
 <dl>
 <dt>beginStroke</dt>
 <dd>Triggered before stroke begins.</dd>
@@ -118,6 +136,7 @@ signaturePad.penColor = "rgb(66, 133, 244)";
 </dl>
 
 You can add listeners to events with [`.addEventListener`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener):
+
 ```javascript
 const signaturePad = new SignaturePad(canvas);
 signaturePad.addEventListener("beginStroke", () => {
@@ -126,8 +145,11 @@ signaturePad.addEventListener("beginStroke", () => {
 ```
 
 ### Tips and tricks
+
 #### Handling high DPI screens
+
 To correctly handle canvas on low and high DPI screens one has to take `devicePixelRatio` into account and scale the canvas accordingly. This scaling is also necessary to properly display signatures loaded via `SignaturePad#fromDataURL`. Here's an example how it can be done:
+
 ```javascript
 function resizeCanvas() {
     const ratio =  Math.max(window.devicePixelRatio || 1, 1);
@@ -140,6 +162,7 @@ function resizeCanvas() {
 window.addEventListener("resize", resizeCanvas);
 resizeCanvas();
 ```
+
 Instead of `resize` event you can listen to screen orientation change, if you're using this library only on mobile devices. You can also throttle the `resize` event - you can find some examples on [this MDN page](https://developer.mozilla.org/en-US/docs/Web/Events/resize).
 
 When you modify width or height of a canvas, it will be automatically cleared by the browser. SignaturePad doesn't know about it by itself, so you can call `signaturePad.clear()` to make sure that `signaturePad.isEmpty()` returns correct value in this case.
@@ -147,13 +170,14 @@ When you modify width or height of a canvas, it will be automatically cleared by
 This clearing of the canvas by the browser can be annoying, especially on mobile devices e.g. when screen orientation is changed. There are a few workarounds though, e.g. you can [lock screen orientation](https://developer.mozilla.org/en-US/docs/Web/API/Screen/lockOrientation), or read an image from the canvas before resizing it and write the image back after.
 
 #### Handling data URI encoded images on the server side
+
 If you are not familiar with data URI scheme, you can read more about it on [Wikipedia](http://en.wikipedia.org/wiki/Data_URI_scheme).
 
 There are 2 ways you can handle data URI encoded images.
 
 You could simply store it in your database as a string and display it in HTML like this:
 
-``` html
+```html
 <img src="data:image/png;base64,iVBORw0K..." />
 ```
 
@@ -161,7 +185,7 @@ but this way has many disadvantages - it's not easy to get image dimensions, you
 
 Thus, more common way is to decode it and store as a file. Here's an example in Ruby:
 
-``` ruby
+```ruby
 require "base64"
 
 data_uri = "data:image/png;base64,iVBORw0K..."
@@ -172,7 +196,7 @@ File.open("signature.png", "wb") { |f| f.write(decoded_image) }
 
 Here's an example in PHP:
 
-``` php
+```php
 $data_uri = "data:image/png;base64,iVBORw0K...";
 $encoded_image = explode(",", $data_uri)[1];
 $decoded_image = base64_decode($encoded_image);
@@ -181,7 +205,7 @@ file_put_contents("signature.png", $decoded_image);
 
 Here's an example in C# for ASP.NET:
 
-``` csharp
+```csharp
 var dataUri = "data:image/png;base64,iVBORw0K...";
 var encodedImage = dataUri.Split(',')[1];
 var decodedImage = Convert.FromBase64String(encodedImage);
@@ -189,10 +213,13 @@ System.IO.File.WriteAllBytes("signature.png", decodedImage);
 ```
 
 #### Removing empty space around a signature
+
 If you'd like to remove (trim) empty space around a signature, you can do it on the server side or the client side. On the server side you can use e.g. ImageMagic and its `trim` option: `convert -trim input.jpg output.jpg`. If you don't have access to the server, or just want to trim the image before submitting it to the server, you can do it on the client side as well. There are a few examples how to do it, e.g. [here](https://github.com/szimek/signature_pad/issues/49#issue-29108215) or [here](https://github.com/szimek/signature_pad/issues/49#issuecomment-260976909) and there's also a tiny library [trim-canvas](https://github.com/agilgur5/trim-canvas) that provides this functionality.
 
 #### Drawing over an image
+
 Demo: <https://jsfiddle.net/szimek/d6a78gwq/>
 
 ## License
+
 Released under the [MIT License](http://www.opensource.org/licenses/MIT).


### PR DESCRIPTION
## Summary

Add two examples to the README for usage of options with `fromDataURL` and `toDataURL`.
- Apply some misc formatting to the README as well

## Details

- some options were added in [v4.0.0](https://github.com/szimek/signature_pad/blob/master/CHANGELOG.md#400) but were not mentioned in the docs
  - I've pointed [multiple](https://github.com/agilgur5/react-signature-canvas/issues/75#issuecomment-1089272704) [users](https://github.com/agilgur5/react-signature-canvas/issues/60#issuecomment-1030713591) to the code for this (instead of the docs) as a result
  - `fromDataURL` had partial options available [earlier](https://github.com/szimek/signature_pad/blob/8145dd499974df25592be7dbd4c583079a9a26c7/src/signature_pad.js#L99), but no examples, and then offsets were added in v4
  - `toDataURL` had options available [earlier](https://github.com/szimek/signature_pad/blob/8145dd499974df25592be7dbd4c583079a9a26c7/src/signature_pad.js#L113) but similarly no examples

- `fromDataURL`: add an example with full `options`
  - add a link to [MDN's `drawImage` docs](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage) for the reference, similar to `toDataURL`'s existing link
- `toDataURL`: add an example with `encoderOptions` on a JPEG

- misc formatting: add new lines after various headings in the README to comply with `markdownlint` etc
  - and after/before code blocks as well
  - also ensure that the language in the code block is immediately after the backticks
    - sometimes there was a space after, but most of the time there wasn't, so just be consistent