### PR TITLE
changelog: add breaking change to v4's `dotSize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Capture pressure when signing ([#566](https://github.com/szimek/signature_pad/pull/566))
 
 #### Breaking changes
+- `dotSize` only accepts a `number` now and no longer accepts a function ([#571](https://github.com/szimek/signature_pad/pull/571))
 - SignaturePad is an event emitter. ([#567](https://github.com/szimek/signature_pad/pull/567)) `onBegin` and `onEnd` options have been moved to events.
 
   The following events were added:


### PR DESCRIPTION
## Summary

add note to v4.0.0 changelog that `dotSize` had a breaking change as well

## Details

- this was changed to only accept a `number`, whereas it previously accepted a `number` or a `function`
  - this was necessary in order to serialize `dotSize` in `#toData` in #571

- found [this line diff](https://github.com/szimek/signature_pad/pull/571/files#diff-1ca065a23dd22378e1c61a8539d9bd5f27a2fc78fbc0c6766645533fc651061cR23) while exploring an upgrade in https://github.com/agilgur5/react-signature-canvas/pull/68#issuecomment-1054862577

## Review Notes

There might be more breaking changes missing from the Changelog? c.f. https://github.com/agilgur5/react-signature-canvas/pull/68#issuecomment-1051305044