### PR TITLE
feat: add support for rendering canvas in external windows

### DIFF
--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -177,11 +177,17 @@ export default class SignaturePad extends SignatureEventTarget {
 
     this.canvas.removeEventListener('pointerdown', this._handlePointerStart);
     this.canvas.removeEventListener('pointermove', this._handlePointerMove);
-    document.removeEventListener('pointerup', this._handlePointerEnd);
+    this.canvas.ownerDocument.removeEventListener(
+      'pointerup',
+      this._handlePointerEnd,
+    );
 
     this.canvas.removeEventListener('mousedown', this._handleMouseDown);
     this.canvas.removeEventListener('mousemove', this._handleMouseMove);
-    document.removeEventListener('mouseup', this._handleMouseUp);
+    this.canvas.ownerDocument.removeEventListener(
+      'mouseup',
+      this._handleMouseUp,
+    );
 
     this.canvas.removeEventListener('touchstart', this._handleTouchStart);
     this.canvas.removeEventListener('touchmove', this._handleTouchMove);
@@ -378,7 +384,10 @@ export default class SignaturePad extends SignatureEventTarget {
 
     this.canvas.addEventListener('pointerdown', this._handlePointerStart);
     this.canvas.addEventListener('pointermove', this._handlePointerMove);
-    document.addEventListener('pointerup', this._handlePointerEnd);
+    this.canvas.ownerDocument.addEventListener(
+      'pointerup',
+      this._handlePointerEnd,
+    );
   }
 
   private _handleMouseEvents(): void {
@@ -386,7 +395,7 @@ export default class SignaturePad extends SignatureEventTarget {
 
     this.canvas.addEventListener('mousedown', this._handleMouseDown);
     this.canvas.addEventListener('mousemove', this._handleMouseMove);
-    document.addEventListener('mouseup', this._handleMouseUp);
+    this.canvas.ownerDocument.addEventListener('mouseup', this._handleMouseUp);
   }
 
   private _handleTouchEvents(): void {

--- a/tests/signature_pad.test.ts
+++ b/tests/signature_pad.test.ts
@@ -165,6 +165,54 @@ describe('user interactions', () => {
     );
     expect(endStroke).toHaveBeenCalled();
   });
+
+  it('call endStroke on pointerup outside canvas when in an external window', () => {
+    const externalCanvas = document.createElement('canvas');
+    externalCanvas.setAttribute('width', '300');
+    externalCanvas.setAttribute('height', '150');
+
+    const externalDocument =
+      document.implementation.createHTMLDocument('New Document');
+
+    externalDocument.body.appendChild(externalCanvas);
+
+    const pad = new SignaturePad(externalCanvas);
+    const endStroke = jest.fn();
+    pad.addEventListener('endStroke', endStroke);
+
+    externalCanvas.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        clientX: 50,
+        clientY: 30,
+        pressure: 1,
+      }),
+    );
+    externalCanvas.dispatchEvent(
+      new PointerEvent('pointermove', {
+        clientX: 240,
+        clientY: 30,
+        pressure: 1,
+      }),
+    );
+    // check that original document is not affected
+    document.dispatchEvent(
+      new PointerEvent('pointerup', {
+        clientX: 150,
+        clientY: 120,
+        pressure: 1,
+      }),
+    );
+    expect(endStroke).not.toHaveBeenCalled();
+    // check that external document emits
+    externalDocument.dispatchEvent(
+      new PointerEvent('pointerup', {
+        clientX: 150,
+        clientY: 120,
+        pressure: 1,
+      }),
+    );
+    expect(endStroke).toHaveBeenCalled();
+  });
 });
 
 describe(`touch events.`, () => {


### PR DESCRIPTION
Closes #636

Note that I've only swapped the event target, as the other `document` methods used are not window/document specific. I also didn't touch the `SignatureEventTarget` iOS compatibility part, as it only affects events dispatched to consumers.