### PR TITLE
Changing heading to "Sizing"

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ signaturePad.addEventListener("beginStroke", () => {
 
 ### Tips and tricks
 
-#### Handling high DPI screens
+#### Sizing
 
-To correctly handle canvas on low and high DPI screens one has to take `devicePixelRatio` into account and scale the canvas accordingly. This scaling is also necessary to properly display signatures loaded via `SignaturePad#fromDataURL`. Here's an example how it can be done:
+To correctly handle low and high DPI screens you have to take `devicePixelRatio` into account and scale the canvas accordingly. This scaling is also necessary to properly display signatures loaded via `SignaturePad#fromDataURL`. Here's an example how it can be done:
 
 ```javascript
 function resizeCanvas() {


### PR DESCRIPTION
I'm observing that sizing the canvas with CSS (`width:800px; height:300px;`) doesn't work (offset between mouse cursor and drawn line). Is this correct?

So there are only 2 way to set the canvas size - right?:
* `width="800" height="300"` in HTML, which will not be responsive, so useless nowadays.
* Through JavaScript (preferably by the one you're showing here). So to me this doesn't look like some additional hint for dealing with some special case (high DPI screens), but rather a **must for everybody** - right?

Some more things I don't understand:
* "You can also throttle the resize event": "throttling" means limiting/reducing - what does this mean in this context? The linked MDN page doesn't say anything about that.
* "SignaturePad doesn't know about it by itself": SignaturePad will not notice the fact that the browser cleared the canvas?
* The entire section "Handling data URI encoded images on the server side" doesn't apply to SVG (just pixel formats), right?

=> I you agree, I'll address this in a separate PR - but I'd need your answers first :-)