### PR TITLE
fix: Fix empty `toDataURL()` in TypeScript

### DIFF
--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -146,7 +146,7 @@ export default class SignaturePad extends SignatureEventTarget {
     type: 'image/svg+xml',
     encoderOptions?: ToSVGOptions,
   ): string;
-  public toDataURL(type?: string, encoderOptions?: number | ToSVGOptions): string;
+  public toDataURL(type?: string, encoderOptions?: number): string;
   public toDataURL(
     type = 'image/png',
     encoderOptions?: number | ToSVGOptions | undefined,

--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -146,7 +146,7 @@ export default class SignaturePad extends SignatureEventTarget {
     type: 'image/svg+xml',
     encoderOptions?: ToSVGOptions,
   ): string;
-  public toDataURL(type?: string, encoderOptions?: number): string;
+  public toDataURL(type?: string, encoderOptions?: number | ToSVGOptions): string;
   public toDataURL(
     type = 'image/png',
     encoderOptions?: number | ToSVGOptions | undefined,

--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -146,7 +146,7 @@ export default class SignaturePad extends SignatureEventTarget {
     type: 'image/svg+xml',
     encoderOptions?: ToSVGOptions,
   ): string;
-  public toDataURL(type: string, encoderOptions?: number): string;
+  public toDataURL(type?: string, encoderOptions?: number): string;
   public toDataURL(
     type = 'image/png',
     encoderOptions?: number | ToSVGOptions | undefined,

--- a/tests/signature_pad.test.ts
+++ b/tests/signature_pad.test.ts
@@ -175,7 +175,7 @@ describe('#toDataURL', () => {
     expect(
       // @ts-expect-error No ToSVGOptions unless it is an SVG
       pad.toDataURL('image/png', { includeBackgroundColor: true }),
-    ).toMatchSnapshot();
+    ).toEqual(expect.stringMatching('data:image/png'));
   });
 });
 

--- a/tests/signature_pad.test.ts
+++ b/tests/signature_pad.test.ts
@@ -167,6 +167,16 @@ describe('#toDataURL', () => {
       pad.toDataURL('image/svg+xml', { includeBackgroundColor: true }),
     ).toMatchSnapshot();
   });
+
+  it('typescript error when not SVG with SVGoptions', () => {
+    const pad = new SignaturePad(canvas, { backgroundColor: '#fcc' });
+    pad.fromData(face);
+
+    expect(
+      // @ts-expect-error No ToSVGOptions unless it is an SVG
+      pad.toDataURL('image/png', { includeBackgroundColor: true }),
+    ).toMatchSnapshot();
+  });
 });
 
 describe('#toSVG', () => {

--- a/tests/signature_pad.test.ts
+++ b/tests/signature_pad.test.ts
@@ -122,6 +122,15 @@ describe('#toData', () => {
 // describe('#fromDataURL', () => {});
 
 describe('#toDataURL', () => {
+  it('returns PNG image by default', () => {
+    const pad = new SignaturePad(canvas);
+    pad.fromData(face);
+
+    expect(pad.toDataURL()).toEqual(
+      expect.stringMatching('data:image/png'),
+    );
+  });
+
   it('returns PNG image in data URL format', () => {
     const pad = new SignaturePad(canvas);
     pad.fromData(face);


### PR DESCRIPTION
The recent change to the `toDataURL` function made the `type` parameter required. It was previously optional. This is a breaking change and most likely an innocent mistake.

Additionally, the type of the `encoderOptions` parameter for the second overload was corrected. The type of `type` could be `string` and its value could be `'image/svg+xml'`. So `ToSVGOptions` should be accepted by the `encoderOptions` parameter. This is not technically a breaking change but it's something I noticed while I was in the area.