### PR TITLE
fix: prevent division by zero in bezier

### DIFF
--- a/src/bezier.ts
+++ b/src/bezier.ts
@@ -33,7 +33,7 @@ export class Bezier {
     const dxm = m1.x - m2.x;
     const dym = m1.y - m2.y;
 
-    const k = l2 / (l1 + l2);
+    const k = l1 + l2 == 0 ? 0 : l2 / (l1 + l2);
     const cm = { x: m2.x + dxm * k, y: m2.y + dym * k };
 
     const tx = s2.x - cm.x;

--- a/tests/bezier.test.ts
+++ b/tests/bezier.test.ts
@@ -31,6 +31,25 @@ describe('.fromPoints', () => {
       expect(curve.endWidth).toBe(2);
     });
   });
+
+  it('returns a new Bézier when points are equal and division by zero may occur', () => {
+    const now = Date.now();
+
+    freezeTimeAt(now, () => {
+      const p1 = new Point(54.4, 10.9, 0.5);
+      const p2 = new Point(54.4, 10.9, 0.5);
+      const p3 = new Point(54.4, 10.9, 0.5);
+      const p4 = new Point(54.4, 10.9, 0.5);
+      const curve = Bezier.fromPoints([p1, p2, p3, p4], { start: 1, end: 1 });
+
+      expect(curve.startPoint).toEqual(p2);
+      expect(curve.control1).toEqual(new Point(54.4, 10.9));
+      expect(curve.control2).toEqual(new Point(54.4, 10.9));
+      expect(curve.endPoint).toBe(p3);
+      expect(curve.startWidth).toBe(1);
+      expect(curve.endWidth).toBe(1);
+    });
+  });
 });
 
 describe('#length', () => {


### PR DESCRIPTION
In some cases Bezier curve calculations could fail due to division by zero.
(for example when signature was generated by older version of the lib or another lib with similar approach to saving canvas data like this one http://keith-wood.name/signature.html)

<img width="438" alt="Screenshot 2024-08-23 at 16 29 42" src="https://github.com/user-attachments/assets/3a619cfb-37a5-4312-b06a-e0b8d3384cdf">

This PR fixes the issue by checking for zero before the division.