### PR TITLE
Add conditional exports to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "exports": {
     "import": "./dist/signature_pad.js",
     "require": "./dist/signature_pad.umd.js",
-    "default": "./dist/signature_pad.umd.js",
+    "default": "./dist/signature_pad.umd.js"
   },
   "scripts": {
     "build": "yarn run lint && yarn run clean && rollup --config && yarn run emit-types && yarn run update-docs",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
   "main": "dist/signature_pad.umd.js",
   "module": "dist/signature_pad.js",
   "types": "dist/types/signature_pad.d.ts",
+  "exports": {
+    "import": "./dist/signature_pad.js",
+    "require": "./dist/signature_pad.umd.js",
+    "default": "./dist/signature_pad.umd.js",
+  },
   "scripts": {
     "build": "yarn run lint && yarn run clean && rollup --config && yarn run emit-types && yarn run update-docs",
     "clean": "yarn run del dist",


### PR DESCRIPTION
I'm in the process of updating to Node 22 and I ran into an issue with the default export not working:

```
src/signature.tsx:25:18 - error TS2351: This expression is not constructable.
  Type 'typeof import("./node_modules/signature_pad/dist/types/signature_pad")' has no construct signatures.

25   this.pad = new SignaturePad(this.canvas, {
```

This PR fixes compatibility with TypeScript's `"nodenext"` module resolution. The `"module"` property is non-standard and not supported by node. The official way is "Conditional Exports":

https://nodejs.org/docs/latest-v22.x/api/packages.html#conditional-exports

This is needed for packages that support CommonJS and ESM where the `"type"` is omitted or set to `"commonjs"`.

(Note: "require" could be omitted, but I was more explicit including both "require" and "default")