### PR TITLE
fix: reset pointerId on stroke end and clear

### DIFF
--- a/src/signature_pad.ts
+++ b/src/signature_pad.ts
@@ -126,6 +126,7 @@ export default class SignaturePad extends SignatureEventTarget {
     this._data = [];
     this._reset(this._getPointGroupOptions());
     this._isEmpty = true;
+    this._strokePointerId = undefined;
   }
 
   public fromDataURL(
@@ -433,8 +434,6 @@ export default class SignaturePad extends SignatureEventTarget {
       return;
     }
 
-    this._strokePointerId = undefined;
-
     event.preventDefault();
     this._strokeEnd(this._pointerEventToSignatureEvent(event));
   };
@@ -564,6 +563,7 @@ export default class SignaturePad extends SignatureEventTarget {
     }
 
     this._drawingStroke = false;
+    this._strokePointerId = undefined;
     this.dispatchEvent(new CustomEvent('endStroke', { detail: event }));
   }
 

--- a/tests/signature_pad.test.ts
+++ b/tests/signature_pad.test.ts
@@ -501,6 +501,80 @@ describe('user interactions', () => {
     ]);
   });
 
+  it('different pointer id events are respected if sequential', () => {
+    const pad = new SignaturePad(canvas);
+    canvas.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        // @ts-expect-error remove pointerId once persistentDeviceId is available
+        persistentDeviceId: 1,
+        pointerId: 1,
+        isPrimary: true,
+        clientX: 50,
+        clientY: 30,
+        pressure: 1,
+        buttons: 1,
+      }),
+    );
+    window.dispatchEvent(
+      new PointerEvent('pointermove', {
+        // @ts-expect-error remove pointerId once persistentDeviceId is available
+        persistentDeviceId: 1,
+        pointerId: 1,
+        isPrimary: true,
+        clientX: 50,
+        clientY: 30,
+        pressure: 1,
+        buttons: 0,
+      }),
+    );
+
+    canvas.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        // @ts-expect-error remove pointerId once persistentDeviceId is available
+        persistentDeviceId: 2,
+        pointerId: 2,
+        isPrimary: true,
+        clientX: 240,
+        clientY: 30,
+        pressure: 1,
+        buttons: 1,
+      }),
+    );
+
+    window.dispatchEvent(
+      new PointerEvent('pointermove', {
+        // @ts-expect-error remove pointerId once persistentDeviceId is available
+        persistentDeviceId: 2,
+        pointerId: 2,
+        isPrimary: true,
+        clientX: 240,
+        clientY: 40,
+        pressure: 1,
+        buttons: 1,
+      }),
+    );
+
+    window.dispatchEvent(
+      new PointerEvent('pointerup', {
+        // @ts-expect-error remove pointerId once persistentDeviceId is available
+        persistentDeviceId: 2,
+        pointerId: 2,
+        isPrimary: true,
+        clientX: 240,
+        clientY: 50,
+        pressure: 1,
+      }),
+    );
+    expect(pad.toData()[0].points).toMatchObject([
+      { x: 50, y: 30, pressure: 1, },
+    ]);
+    expect(pad.toData()[1].points).toMatchObject([
+      { x: 240, y: 30, pressure: 1 },
+      { x: 240, y: 40, pressure: 1 },
+      { x: 240, y: 50, pressure: 1 },
+    ]);
+  });
+
   it('call endStroke on pointerup outside canvas', () => {
     const pad = new SignaturePad(canvas);
     const endStroke = jest.fn();


### PR DESCRIPTION
Fixes the deadlock issue in #834.

Did not separately add a test for clear, as that's sort of a escape hatch for when things go wrong somewhere else - and that potential event is not very well described in a test.

